### PR TITLE
Add Zuul project definition

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -9,3 +9,18 @@
     vars:
       go_command: test ./...
       go_version: 1.20.5
+- project:
+    merge-mode: squash-merge
+    default-branch: main
+    check:
+        jobs:
+          - golang-lint
+          - golang-test
+    check-post:
+        jobs:
+          - golang-lint
+          - golang-test
+    gate:
+        jobs:
+          - golang-lint
+          - golang-test

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -16,11 +16,3 @@
         jobs:
           - golang-lint
           - golang-test
-    check-post:
-        jobs:
-          - golang-lint
-          - golang-test
-    gate:
-        jobs:
-          - golang-lint
-          - golang-test


### PR DESCRIPTION
Zuuls project definition was missing in the `.zuul.yaml`, this is needed to run zuul jobs.