### PR TITLE
update go and use longnames

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine3.18 as builder
+FROM docker.io/golang:1.21.4-alpine3.18 as builder
 
 WORKDIR /build
 
@@ -6,7 +6,7 @@ COPY . .
 
 RUN go build -o status-page-api main.go
 
-FROM alpine:3.18
+FROM docker.io/alpine:3.18
 
 WORKDIR /app
 


### PR DESCRIPTION
Update to Go 1.21.4 and use container longnames