### PR TITLE
fix vulnerabilities: update alpine packages

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,6 @@
 FROM docker.io/golang:1.21.4-alpine3.18 as builder
 
-RUN apk upgrade
+RUN apk upgrade --no-cache
 
 WORKDIR /build
 
@@ -10,7 +10,7 @@ RUN go build -o status-page-api main.go
 
 FROM docker.io/alpine:3.18
 
-RUN apk upgrade
+RUN apk upgrade --no-cache
 
 WORKDIR /app
 

--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,7 @@
 FROM docker.io/golang:1.21.4-alpine3.18 as builder
 
+RUN apk upgrade
+
 WORKDIR /build
 
 COPY . .
@@ -7,6 +9,8 @@ COPY . .
 RUN go build -o status-page-api main.go
 
 FROM docker.io/alpine:3.18
+
+RUN apk upgrade
 
 WORKDIR /app
 


### PR DESCRIPTION
Update alpine images to fix
[CVE-2023-5363](https://avd.aquasec.com/nvd/cve-2023-5363)
[CVE-2023-5363](https://avd.aquasec.com/nvd/cve-2023-5363)
[CVE-2023-5678](https://avd.aquasec.com/nvd/cve-2023-5678)
[CVE-2023-5678](https://avd.aquasec.com/nvd/cve-2023-5678)
 these are fixed in `3.1.4-r0` of `libssl3` and `libcrypto3`