### PR TITLE
Fix connection string env

### DIFF
--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -105,10 +105,12 @@ func pflagNormalizer(_ *pflag.FlagSet, name string) pflag.NormalizedName {
 }
 
 func buildConfig() *Config {
+	quoteReplacer := strings.NewReplacer("\"", "", "'", "")
+
 	return &Config{
 		AllowedOrigins: viper.GetStringSlice(allowedOrigins),
 		Database: Database{
-			ConnectionString: strings.TrimSpace(viper.GetString(databaseConnectionString)),
+			ConnectionString: strings.TrimSpace(quoteReplacer.Replace((viper.GetString(databaseConnectionString)))),
 		},
 		ListenAddress:    strings.TrimSpace(viper.GetString(listenAddress)),
 		ProvisioningFile: strings.TrimSpace(viper.GetString(provisioningFile)),


### PR DESCRIPTION
The database connection string contains spaces to delimit key value pairs. To stop the env from pruning the connection string on the first space, the env value must be wrapped in quotes (`"` or `'`). When running locally, this does not seem to generate any kind of problem. But when running with `compose` or `kubernetes`, the quotes won't be removed automatically and are part of the configuration value. This in turn invalidates the first key and last value of the connection string.

As solution quotes get stripped from the configuration value.